### PR TITLE
Feature/rafi/create an endpoint to add a lecture in a course

### DIFF
--- a/src/controllers/module.controller.ts
+++ b/src/controllers/module.controller.ts
@@ -1,0 +1,29 @@
+import type { Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { authService } from '../services/auth.service';
+import { moduleService } from '../services/module.service';
+import { sendResponse } from '../utils/api.util';
+import { validate } from '../utils/validate.util';
+import {
+    addModuleSchema, courseIdModuleSchema
+} from '../validations/module.validate';
+
+class ModuleController {
+
+    async addLecture(req: Request, res: Response) {
+        const userPayload = await authService.getTokenPayload(req, 'ACCESS');
+        const body = validate(req, addModuleSchema, 'body');
+        const courseId = validate(req, courseIdModuleSchema, 'params');
+
+        await moduleService.addLecture(userPayload!.userId, courseId, body);
+
+        return sendResponse(res, {
+            statusCode: StatusCodes.CREATED,
+            success: true,
+            message: 'Successfully created a module.'
+        });
+    }
+
+}
+
+export const moduleController = new ModuleController();

--- a/src/controllers/module.controller.ts
+++ b/src/controllers/module.controller.ts
@@ -5,14 +5,14 @@ import { moduleService } from '../services/module.service';
 import { sendResponse } from '../utils/api.util';
 import { validate } from '../utils/validate.util';
 import {
-    lectureSchema, courseIdModuleSchema
+    addLectureSchema, courseIdModuleSchema
 } from '../validations/module.validate';
 
 class ModuleController {
 
     async addLecture(req: Request, res: Response) {
         const userPayload = await authService.getTokenPayload(req, 'ACCESS');
-        const body = validate(req, lectureSchema, 'body');
+        const body = validate(req, addLectureSchema, 'body');
         const courseId = validate(req, courseIdModuleSchema, 'params');
 
         await moduleService.addLecture(userPayload!.userId, courseId, body);

--- a/src/controllers/module.controller.ts
+++ b/src/controllers/module.controller.ts
@@ -20,7 +20,7 @@ class ModuleController {
         return sendResponse(res, {
             statusCode: StatusCodes.CREATED,
             success: true,
-            message: 'Successfully created a module.'
+            message: 'Successfully created a lecture.'
         });
     }
 

--- a/src/controllers/module.controller.ts
+++ b/src/controllers/module.controller.ts
@@ -5,14 +5,14 @@ import { moduleService } from '../services/module.service';
 import { sendResponse } from '../utils/api.util';
 import { validate } from '../utils/validate.util';
 import {
-    addModuleSchema, courseIdModuleSchema
+    lectureSchema, courseIdModuleSchema
 } from '../validations/module.validate';
 
 class ModuleController {
 
     async addLecture(req: Request, res: Response) {
         const userPayload = await authService.getTokenPayload(req, 'ACCESS');
-        const body = validate(req, addModuleSchema, 'body');
+        const body = validate(req, lectureSchema, 'body');
         const courseId = validate(req, courseIdModuleSchema, 'params');
 
         await moduleService.addLecture(userPayload!.userId, courseId, body);

--- a/src/database/entities/Module.ts
+++ b/src/database/entities/Module.ts
@@ -12,7 +12,7 @@ import { Lecture } from './Lecture';
 import { Quiz } from './Quiz';
 import { ModuleCompletion } from './ModuleCompletion';
 
-enum ModuleType {
+export enum ModuleType {
     LECTURE = 'lecture',
     QUIZ = 'quiz'
 }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -21,7 +21,7 @@ router.post('/courses/:courseId/enroll', authenticate('ACCESS'),
 
 // Course
 router.post('/courses', authenticate('ACCESS'), courseController.add);
-router.post('/courses/:courseId/lecture', authenticate('ACCESS'),
+router.post('/courses/:courseId/modules/lectures', authenticate('ACCESS'),
     moduleController.addLecture);
 
 export default router;

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { courseController } from '../controllers/course.controller';
 import {
     courseEnrollmentController
 } from '../controllers/courseEnrollment.controller';
+import { moduleController } from '../controllers/module.controller';
 import authenticate from '../middlewares/authenticate.middleware';
 
 const router = Router();
@@ -20,5 +21,7 @@ router.post('/courses/:courseId/enroll', authenticate('ACCESS'),
 
 // Course
 router.post('/courses', authenticate('ACCESS'), courseController.add);
+router.post('/courses/:courseId/lecture', authenticate('ACCESS'),
+    moduleController.addLecture);
 
 export default router;

--- a/src/services/course.service.ts
+++ b/src/services/course.service.ts
@@ -1,6 +1,7 @@
+import { StatusCodes } from 'http-status-codes';
 import { Course } from '../database/entities/Course';
 import { UserRole } from '../database/entities/User';
-import { Errors } from '../utils/error.util';
+import { ResponseError, Errors } from '../utils/error.util';
 import type { AddCourseType } from '../validations/course.validate';
 import { userService } from './user.service';
 
@@ -15,6 +16,17 @@ class CourseService {
         const course = Course.create({ instructorId, ...rawCourse });
 
         await Course.save(course);
+    }
+
+    async get(courseId: number) {
+        const course = await Course.findOneBy({ id: courseId });
+        if (!course) {
+            throw new ResponseError(
+                'Course not found.',
+                StatusCodes.NOT_FOUND);
+        }
+
+        return course;
     }
 
 }

--- a/src/services/courseEnrollment.service.ts
+++ b/src/services/courseEnrollment.service.ts
@@ -1,7 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { CourseEnrollment } from '../database/entities/CourseEnrollment';
 import type {
-    CourseEnrollmentInterface
+    AddCourseEnrollmentType
 } from '../validations/courseEnrollment.validate';
 import type { UserPayload } from '../typings/auth';
 import { ResponseError } from '../utils/error.util';
@@ -11,7 +11,7 @@ class CourseEnrollmentService {
 
     async enrollNewCourse(
         userPayload: UserPayload,
-        { courseId }: CourseEnrollmentInterface) {
+        { courseId }: AddCourseEnrollmentType) {
         const userId = userPayload.userId;
         const userCourseEnrolled = await CourseEnrollment
             .find({

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -1,0 +1,26 @@
+import type { ModuleInterface } from '../validations/module.validate';
+import { courseService } from '../services/course.service';
+import { Errors } from '../utils/error.util';
+import { Module } from '../database/entities/Module';
+
+class ModuleService {
+
+    async addLecture(
+        instructorId: number,
+        courseId: ModuleInterface['courseId'],
+        rawModule: ModuleInterface) {
+
+        rawModule.courseId = courseId;
+        const course = await courseService.get(courseId);
+        if (course.instructorId !== instructorId) {
+            throw Errors.NO_PERMISSION;
+        }
+
+        const module = Module.create({ ...rawModule });
+
+        await Module.save(module);
+    }
+
+}
+
+export const moduleService = new ModuleService();

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -1,4 +1,4 @@
-import type { LectureInterface } from '../validations/module.validate';
+import type { AddLectureType } from '../validations/module.validate';
 import { courseService } from '../services/course.service';
 import { Errors } from '../utils/error.util';
 import { Module, ModuleType } from '../database/entities/Module';
@@ -8,8 +8,8 @@ class ModuleService {
 
     async addLecture(
         instructorId: number,
-        courseId: LectureInterface['courseId'],
-        rawModule: LectureInterface) {
+        courseId: AddLectureType['courseId'],
+        rawModule: AddLectureType) {
 
         rawModule.courseId = courseId;
         rawModule.type = ModuleType.LECTURE;
@@ -23,7 +23,7 @@ class ModuleService {
         const module = await Module.save(moduleData);
 
         const moduleId = module.id;
-        const lectureLink = rawModule.lecture_link;
+        const lectureLink = rawModule.lectureLink;
 
         const lectureData = Lecture.create({
             moduleId,

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -1,25 +1,36 @@
-import type { ModuleInterface } from '../validations/module.validate';
+import type { LectureInterface } from '../validations/module.validate';
 import { courseService } from '../services/course.service';
 import { Errors } from '../utils/error.util';
 import { Module, ModuleType } from '../database/entities/Module';
+import { Lecture } from '../database/entities/Lecture';
 
 class ModuleService {
 
     async addLecture(
         instructorId: number,
-        courseId: ModuleInterface['courseId'],
-        rawModule: ModuleInterface) {
+        courseId: LectureInterface['courseId'],
+        rawModule: LectureInterface) {
 
         rawModule.courseId = courseId;
         rawModule.type = ModuleType.LECTURE;
+
         const course = await courseService.get(courseId);
         if (course.instructorId !== instructorId) {
             throw Errors.NO_PERMISSION;
         }
 
-        const module = Module.create({ ...rawModule });
+        const moduleData = Module.create({ ...rawModule });
+        const module = await Module.save(moduleData);
 
-        await Module.save(module);
+        const moduleId = module.id;
+        const lectureLink = rawModule.lecture_link;
+
+        const lectureData = await Lecture.create({
+            moduleId,
+            lectureLink
+        });
+
+        await Lecture.save(lectureData);
     }
 
 }

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -1,7 +1,7 @@
 import type { ModuleInterface } from '../validations/module.validate';
 import { courseService } from '../services/course.service';
 import { Errors } from '../utils/error.util';
-import { Module } from '../database/entities/Module';
+import { Module, ModuleType } from '../database/entities/Module';
 
 class ModuleService {
 
@@ -11,6 +11,7 @@ class ModuleService {
         rawModule: ModuleInterface) {
 
         rawModule.courseId = courseId;
+        rawModule.type = ModuleType.LECTURE;
         const course = await courseService.get(courseId);
         if (course.instructorId !== instructorId) {
             throw Errors.NO_PERMISSION;

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -25,7 +25,7 @@ class ModuleService {
         const moduleId = module.id;
         const lectureLink = rawModule.lecture_link;
 
-        const lectureData = await Lecture.create({
+        const lectureData = Lecture.create({
             moduleId,
             lectureLink
         });

--- a/src/validations/courseEnrollment.validate.ts
+++ b/src/validations/courseEnrollment.validate.ts
@@ -1,11 +1,11 @@
 import joi from 'joi';
 
-export interface CourseEnrollmentInterface {
+export interface AddCourseEnrollmentType {
     userId: number;
     courseId: number;
 }
 
-export const courseEnrollmentSchema = joi.object<CourseEnrollmentInterface>({
+export const courseEnrollmentSchema = joi.object<AddCourseEnrollmentType>({
     courseId: joi.number()
         .required()
 });

--- a/src/validations/module.validate.ts
+++ b/src/validations/module.validate.ts
@@ -1,16 +1,16 @@
 import joi from 'joi';
 import type { ModuleType } from '../database/entities/Module';
 
-export interface ModuleInterface {
+export interface AddModuleType {
     courseId: number;
     order: number;
     name: string;
     type: ModuleType;
 }
 
-export interface LectureInterface extends ModuleInterface {
-    module_id: number;
-    lecture_link: string;
+export interface AddLectureType extends AddModuleType {
+    moduleId: number;
+    lectureLink: string;
 }
 
 // Module
@@ -20,20 +20,22 @@ export const courseIdModuleSchema = joi.object({
 });
 
 // Lecture
-export const lectureSchema = joi.object<LectureInterface>({
+export const addLectureSchema = joi.object<AddLectureType>({
     order: joi.number()
         .required()
         .description('The order of the module in the course.'),
 
     name: joi.string()
         .required()
+        .max(64)
         .description('The name of the module.'),
 
-    module_id: joi.number()
+    moduleId: joi.number()
         .required()
         .description('The id of the module the lecture belongs to.'),
 
-    lecture_link: joi.string()
+    lectureLink: joi.string()
         .required()
+        .max(64)
         .description('The link to the lecture.')
 });

--- a/src/validations/module.validate.ts
+++ b/src/validations/module.validate.ts
@@ -1,5 +1,5 @@
 import joi from 'joi';
-import { ModuleType } from '../database/entities/Module';
+import type { ModuleType } from '../database/entities/Module';
 
 export interface ModuleInterface {
     courseId: number;
@@ -21,9 +21,4 @@ export const addModuleSchema = joi.object<ModuleInterface>({
     name: joi.string()
         .required()
         .description('The name of the module.'),
-
-    type: joi.string()
-        .required()
-        .description('The type of the module.')
-        .valid(Object.values(ModuleType))
 });

--- a/src/validations/module.validate.ts
+++ b/src/validations/module.validate.ts
@@ -8,12 +8,19 @@ export interface ModuleInterface {
     type: ModuleType;
 }
 
+export interface LectureInterface extends ModuleInterface {
+    module_id: number;
+    lecture_link: string;
+}
+
+// Module
 export const courseIdModuleSchema = joi.object({
     courseId: joi.number().required()
         .description('The id of the course the module belongs to.'),
 });
 
-export const addModuleSchema = joi.object<ModuleInterface>({
+// Lecture
+export const lectureSchema = joi.object<LectureInterface>({
     order: joi.number()
         .required()
         .description('The order of the module in the course.'),
@@ -21,4 +28,12 @@ export const addModuleSchema = joi.object<ModuleInterface>({
     name: joi.string()
         .required()
         .description('The name of the module.'),
+
+    module_id: joi.number()
+        .required()
+        .description('The id of the module the lecture belongs to.'),
+
+    lecture_link: joi.string()
+        .required()
+        .description('The link to the lecture.')
 });

--- a/src/validations/module.validate.ts
+++ b/src/validations/module.validate.ts
@@ -1,0 +1,29 @@
+import joi from 'joi';
+import { ModuleType } from '../database/entities/Module';
+
+export interface ModuleInterface {
+    courseId: number;
+    order: number;
+    name: string;
+    type: ModuleType;
+}
+
+export const courseIdModuleSchema = joi.object({
+    courseId: joi.number().required()
+        .description('The id of the course the module belongs to.'),
+});
+
+export const addModuleSchema = joi.object<ModuleInterface>({
+    order: joi.number()
+        .required()
+        .description('The order of the module in the course.'),
+
+    name: joi.string()
+        .required()
+        .description('The name of the module.'),
+
+    type: joi.string()
+        .required()
+        .description('The type of the module.')
+        .valid(Object.values(ModuleType))
+});


### PR DESCRIPTION
#### Issue:  https://trello.com/c/LOo05Hi0/58-be-create-an-endpoint-to-add-a-lecture-in-a-course-include-order
#### Step to reproduce:
HIT POST /courses/:courseId/lecture
Authentication: Access

#### Example JSON Data:
```json
{
    "order": 1,
    "name": "Matematika Lanjut",
    "lecture_link": "https://www.youtube.com/watch?v=fMIn43MiwG8"
}
```

#### See result:
IF userId not instructorId at course:
Status Code: FORBIDDEN
```json
{
    "success": false,
    "message": "You don't have the permission to access this content."
}
```

IF success add lecture:
Status Code: CREATED
```json
{
    "success": true,
    "message": "Successfully created a lecture."
}
```

NB:
1. Belum tau gimana implementasi validasi `joi` yang efisien. Soalnya di module kan bisa ada lecture sama quiz. Soalnya kolom di module yang `order, name` itu pasti sama, jadi maksudnya biar nulis kolom module sekali aja, sisanya tinggal tambahin lecture/quiz.
2. Belum tau gimana cara validasi pake joi dengan dua sumber request: `params` dan `body`. Saat ini malah bikin dua schema wkwkw.
3. Fiturnya belum dicoba, karena belum ada Test Unit.