### PR TITLE
Create an endpoint to add Quiz to module and fix bug cannot add lecture

### DIFF
--- a/src/controllers/module.controller.ts
+++ b/src/controllers/module.controller.ts
@@ -5,7 +5,7 @@ import { moduleService } from '../services/module.service';
 import { sendResponse } from '../utils/api.util';
 import { validate } from '../utils/validate.util';
 import {
-    addLectureSchema, courseIdModuleSchema
+    addLectureSchema, courseIdModuleSchema, addQuizSchema
 } from '../validations/module.validate';
 
 class ModuleController {
@@ -13,14 +13,30 @@ class ModuleController {
     async addLecture(req: Request, res: Response) {
         const userPayload = await authService.getTokenPayload(req, 'ACCESS');
         const body = validate(req, addLectureSchema, 'body');
-        const courseId = validate(req, courseIdModuleSchema, 'params');
+        const param = validate(req, courseIdModuleSchema, 'params');
 
-        await moduleService.addLecture(userPayload!.userId, courseId, body);
+        await moduleService.addLecture(userPayload!.userId,
+            param.courseId, body);
 
         return sendResponse(res, {
             statusCode: StatusCodes.CREATED,
             success: true,
             message: 'Successfully created a lecture.'
+        });
+    }
+
+    async addQuiz(req: Request, res: Response) {
+        const userPayload = await authService.getTokenPayload(req, 'ACCESS');
+        const body = validate(req, addQuizSchema, 'body');
+        const param = validate(req, courseIdModuleSchema, 'params');
+
+        await moduleService.addQuiz(userPayload!.userId,
+            param.courseId, body);
+
+        return sendResponse(res, {
+            statusCode: StatusCodes.CREATED,
+            success: true,
+            message: 'Successfully created a quiz.'
         });
     }
 

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -29,6 +29,8 @@ router.get('/courses/:courseId', authenticate('ACCESS'),
 router.post('/courses', authenticate('ACCESS'), courseController.add);
 router.post('/courses/:courseId/modules/lectures', authenticate('ACCESS'),
     moduleController.addLecture);
+router.post('/courses/:courseId/modules/quizzes', authenticate('ACCESS'),
+    moduleController.addQuiz);
 
 // Approval
 router.get('/approval/register', authenticate('ACCESS'),

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -1,8 +1,11 @@
-import type { AddLectureType } from '../validations/module.validate';
+import type {
+    AddLectureType, AddModuleType
+} from '../validations/module.validate';
 import { courseService } from '../services/course.service';
 import { Errors } from '../utils/error.util';
 import { Module, ModuleType } from '../database/entities/Module';
 import { Lecture } from '../database/entities/Lecture';
+import { Quiz } from '../database/entities/Quiz';
 
 class ModuleService {
 
@@ -31,6 +34,31 @@ class ModuleService {
         });
 
         await Lecture.save(lectureData);
+    }
+
+    async addQuiz(
+        instructorId: number,
+        courseId: AddModuleType['courseId'],
+        rawModule: AddModuleType) {
+
+        rawModule.courseId = courseId;
+        rawModule.type = ModuleType.QUIZ;
+
+        const course = await courseService.get(courseId);
+        if (course.instructorId !== instructorId) {
+            throw Errors.NO_PERMISSION;
+        }
+
+        const moduleData = Module.create({ ...rawModule });
+        const module = await Module.save(moduleData);
+
+        const moduleId = module.id;
+
+        const quizData = Quiz.create({
+            moduleId
+        });
+
+        await Quiz.save(quizData);
     }
 
 }

--- a/src/validations/module.validate.ts
+++ b/src/validations/module.validate.ts
@@ -6,10 +6,10 @@ export interface AddModuleType {
     order: number;
     name: string;
     type: ModuleType;
+    moduleId: number;
 }
 
 export interface AddLectureType extends AddModuleType {
-    moduleId: number;
     lectureLink: string;
 }
 
@@ -30,12 +30,20 @@ export const addLectureSchema = joi.object<AddLectureType>({
         .max(64)
         .description('The name of the module.'),
 
-    moduleId: joi.number()
-        .required()
-        .description('The id of the module the lecture belongs to.'),
-
     lectureLink: joi.string()
         .required()
         .max(64)
         .description('The link to the lecture.')
+});
+
+// Quiz
+export const addQuizSchema = joi.object<AddModuleType>({
+    order: joi.number()
+        .required()
+        .description('The order of the module in the course.'),
+
+    name: joi.string()
+        .required()
+        .max(64)
+        .description('The name of the module.')
 });


### PR DESCRIPTION
#### Issue: https://trello.com/c/KBVYoA8o/59-be-create-an-endpoint-to-add-a-quiz-in-a-course-include-order
#### How to reproduce:
HIT POST /courses/:courseId/quizzes
Authentication: Access

#### Example JSON Data:
```json
{
    "order": 1,
    "name": "Quiz 1"
}
```

#### See result:
IF userId not instructorId at course:
Status Code: FORBIDDEN
```json
{
    "success": false,
    "message": "You don't have the permission to access this content."
}
```

IF success add quiz:
Status Code: CREATED
```json
{
    "success": true,
    "message": "Successfully created a quiz."
}
```