### PR TITLE
Add endpoint to create question and answer to specific quiz

### DIFF
--- a/scripts/seeder.ts
+++ b/scripts/seeder.ts
@@ -161,7 +161,7 @@ async function seedData() {
             moduleId: 5
         })
     ];
-    await Quiz.save(quizzes);
+    await Lecture.save(quizzes);
 }
 
 AppDataSource.initialize()

--- a/scripts/seeder.ts
+++ b/scripts/seeder.ts
@@ -161,7 +161,7 @@ async function seedData() {
             moduleId: 5
         })
     ];
-    await Lecture.save(quizzes);
+    await Quiz.save(quizzes);
 }
 
 AppDataSource.initialize()

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,6 @@
 import { RegisterTest, LoginTest } from './tests/authTest';
 import { ApprovalTest } from './tests/approvalTest';
+import { QuizInstructorTest } from './tests/quizTest';
 
 describe('Testing Auth Functions', () => {
     RegisterTest();
@@ -8,4 +9,8 @@ describe('Testing Auth Functions', () => {
 
 describe('Testing Admin Functions', () => {
     ApprovalTest();
+});
+
+describe('Testing Instructor Functions', () => {
+    QuizInstructorTest();
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,6 +1,7 @@
 import { RegisterTest, LoginTest } from './tests/authTest';
 import { ApprovalTest } from './tests/approvalTest';
-import { QuizInstructorTest } from './tests/quizTest';
+import { QuestionInstructorTest } from './tests/quizTest';
+import { CourseInstructorTest } from './tests/courseTest';
 
 describe('Testing Auth Functions', () => {
     RegisterTest();
@@ -8,9 +9,17 @@ describe('Testing Auth Functions', () => {
 });
 
 describe('Testing Admin Functions', () => {
-    ApprovalTest();
+    describe('Testing Approval Functions', () => {
+        ApprovalTest();
+    });
 });
 
 describe('Testing Instructor Functions', () => {
-    QuizInstructorTest();
+    describe('Testing Course Functions', () => {
+        CourseInstructorTest();
+    });
+
+    describe('Testing Question Functions', () => {
+        QuestionInstructorTest();
+    });
 });

--- a/src/__tests__/tests/courseTest.ts
+++ b/src/__tests__/tests/courseTest.ts
@@ -1,0 +1,79 @@
+import request from 'supertest';
+import { StatusCodes } from 'http-status-codes';
+import { userInstructorVerifiedDataTest } from './userData';
+import app from '../../app';
+
+export const CourseInstructorTest = () => {
+    let token: string;
+    beforeAll(async () => {
+        const response = await request(app)
+            .post('/auth/login')
+            .send({
+                email: userInstructorVerifiedDataTest.email,
+                password: userInstructorVerifiedDataTest.password,
+            });
+
+        token = `Bearer ${response.body.data.accessToken}`;
+    });
+
+    describe('POST /courses', () => {
+        it('should return CREATED IF form is valid ' +
+        'and logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses')
+                .set('Authorization', token)
+                .send({
+                    name: 'Test Course',
+                    description: 'Test Course Description',
+                });
+
+            expect(response.status).toBe(StatusCodes.CREATED);
+        });
+
+        it('should return BAD REQUEST IF form is invalid ' +
+        'and logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses')
+                .set('Authorization', token)
+                .send({
+                    name: '',
+                    description: 'Test Course Description',
+                });
+
+            expect(response.status).toBe(StatusCodes.BAD_REQUEST);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything(),
+            });
+        });
+
+        it('should return UNAUTHORIZED IF not logged in as instructor',
+            async () => {
+                const response = await request(app)
+                    .post('/courses')
+                    .set('Authorization', 'Bearer invalid_token')
+                    .send({
+                        name: 'Test Course',
+                        description: 'Test Course Description',
+                    });
+
+                expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+            });
+
+        it('should return UNAUTHORIZED IF not logged in',
+            async () => {
+                const response = await request(app)
+                    .post('/courses')
+                    .send({
+                        name: 'Test Course',
+                        description: 'Test Course Description',
+                    });
+
+                expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything(),
+                });
+            });
+    });
+};

--- a/src/__tests__/tests/quizTest.ts
+++ b/src/__tests__/tests/quizTest.ts
@@ -1,0 +1,191 @@
+import request from 'supertest';
+import { StatusCodes } from 'http-status-codes';
+import { userInstructorVerifiedDataTest } from './userData';
+import app from '../../app';
+
+export const QuizInstructorTest = () => {
+    let token: string;
+    const exampleQuestion = {
+        question: 'What is the capital of Indonesia?',
+        questionOptions: [
+            {
+                option: 'Jakarta',
+                isCorrectAnswer: true
+            },
+            {
+                option: 'Bandung',
+                isCorrectAnswer: false
+            },
+            {
+                option: 'Surabaya',
+                isCorrectAnswer: false
+            },
+            {
+                option: 'Malang',
+                isCorrectAnswer: false
+            }
+        ]
+    };
+
+    beforeAll(async () => {
+        const response = await request(app)
+            .post('/auth/login')
+            .send({
+                email: userInstructorVerifiedDataTest.email,
+                password: userInstructorVerifiedDataTest.password,
+            });
+
+        token = `Bearer ${response.body.data.accessToken}`;
+    });
+
+    describe('POST /courses/:courseId/quizzes/:quizId/questions', () => {
+        it('should return CREATED IF logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/1/questions')
+                .set('Authorization', token)
+                .send(exampleQuestion);
+
+            expect(response.statusCode).toBe(StatusCodes.CREATED);
+            expect(response.body).toMatchObject({
+                status: 'success',
+                message: expect.anything()
+            });
+        });
+
+        it('should return UNAUTHORIZED IF not logged in as instructor',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/quizzes/1/questions')
+                    .send(exampleQuestion);
+
+                expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF courseId is not a number',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/a/quizzes/1/questions')
+                    .set('Authorization', token)
+                    .send(exampleQuestion);
+
+                expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF quizId is not a number',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/quizzes/a/questions')
+                    .set('Authorization', token)
+                    .send(exampleQuestion);
+
+                expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF question is not provided',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/quizzes/1/questions')
+                    .set('Authorization', token)
+                    .send({
+                        question: '',
+                        questionOptions: exampleQuestion.questionOptions
+                    });
+
+                expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF questionOptions is not provided',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/quizzes/1/questions')
+                    .set('Authorization', token)
+                    .send({
+                        question: exampleQuestion.question,
+                        questionOptions: []
+                    });
+
+                expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF questionOptions ' +
+        'length is not more than 1', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/1/questions')
+                .set('Authorization', token)
+                .send({
+                    question: exampleQuestion.question,
+                    questionOptions: [
+                        {
+                            option: 'Jakarta',
+                            isCorrectAnswer: true
+                        }
+                    ]
+                });
+
+            expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
+            });
+        });
+
+        it('should return BAD REQUEST IF questionOptions is not an array',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/quizzes/1/questions')
+                    .set('Authorization', token)
+                    .send({
+                        question: exampleQuestion.question,
+                        questionOptions: 'a'
+                    });
+
+                expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything()
+                });
+            });
+
+        it('should return BAD REQUEST IF questionOptions ' +
+            'is not an array of objects', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/1/questions')
+                .set('Authorization', token)
+                .send({
+                    question: exampleQuestion.question,
+                    questionOptions: [
+                        'a',
+                        'b',
+                        'c',
+                        'd'
+                    ]
+                });
+
+            expect(response.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
+            });
+        });
+    });
+};

--- a/src/__tests__/tests/quizTest.ts
+++ b/src/__tests__/tests/quizTest.ts
@@ -3,7 +3,7 @@ import { StatusCodes } from 'http-status-codes';
 import { userInstructorVerifiedDataTest } from './userData';
 import app from '../../app';
 
-export const QuizInstructorTest = () => {
+export const QuestionInstructorTest = () => {
     let token: string;
     const exampleQuestion = {
         question: 'What is the capital of Indonesia?',
@@ -38,8 +38,102 @@ export const QuizInstructorTest = () => {
         token = `Bearer ${response.body.data.accessToken}`;
     });
 
+    describe('POST /courses/:courseId/modules/quizzes', () => {
+        it('should return CREATED IF form is valid ' +
+        'and logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses/1/modules/quizzes')
+                .set('Authorization', token)
+                .send({
+                    name: 'Test Quiz',
+                    order: 10,
+                });
+
+            expect(response.status).toBe(StatusCodes.CREATED);
+            expect(response.body).toMatchObject({
+                status: 'success',
+                message: expect.anything()
+            });
+        });
+
+        it('should return BAD_REQUEST IF form is invalid ' +
+        'and logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses/1/modules/quizzes')
+                .set('Authorization', token)
+                .send({
+                    name: '',
+                    order: 10,
+                });
+
+            expect(response.status).toBe(StatusCodes.BAD_REQUEST);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything(),
+            });
+        });
+
+        it('should return UNAUTHORIZED IF not logged in as instructor',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/modules/quizzes')
+                    .set('Authorization', 'Bearer invalid_token');
+
+                expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything(),
+                });
+            });
+
+        it('should return UNAUTHORIZED IF not logged in',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/1/modules/quizzes');
+
+                expect(response.status).toBe(StatusCodes.UNAUTHORIZED);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything(),
+                });
+            });
+
+        it('should return BAD REQUEST IF courseId is not number',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/invalid_id/modules/quizzes')
+                    .set('Authorization', token)
+                    .send({
+                        name: 'Test Quiz',
+                        order: 10,
+                    });
+                expect(response.status).toBe(StatusCodes.BAD_REQUEST);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything(),
+                });
+            });
+
+        it('should return NOT_FOUND IF courseId is invalid',
+            async () => {
+                const response = await request(app)
+                    .post('/courses/100/modules/quizzes')
+                    .set('Authorization', token)
+                    .send({
+                        name: 'Test Quiz',
+                        order: 10,
+                    });
+                expect(response.status).toBe(StatusCodes.NOT_FOUND);
+                expect(response.body).toMatchObject({
+                    status: 'fail',
+                    message: expect.anything(),
+                });
+            });
+    });
+
     describe('POST /courses/:courseId/quizzes/:quizId/questions', () => {
-        it('should return CREATED IF logged in as instructor', async () => {
+        it('should return CREATED IF form is valid ' +
+            'and logged in as instructor', async () => {
             const response = await request(app)
                 .post('/courses/1/quizzes/1/questions')
                 .set('Authorization', token)
@@ -52,18 +146,18 @@ export const QuizInstructorTest = () => {
             });
         });
 
-        it('should return UNAUTHORIZED IF not logged in as instructor',
-            async () => {
-                const response = await request(app)
-                    .post('/courses/1/quizzes/1/questions')
-                    .send(exampleQuestion);
+        it('should return UNAUTHORIZED IF form is valid ' +
+            'and logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/1/questions')
+                .send(exampleQuestion);
 
-                expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
-                expect(response.body).toMatchObject({
-                    status: 'fail',
-                    message: expect.anything()
-                });
+            expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
             });
+        });
 
         it('should return BAD REQUEST IF courseId is not a number',
             async () => {
@@ -187,31 +281,31 @@ export const QuizInstructorTest = () => {
                 message: expect.anything()
             });
         });
-    });
 
-    it('should return BAD REQUEST IF quizId not found', async () => {
-        const response = await request(app)
-            .post('/courses/1/quizzes/100/questions')
-            .set('Authorization', token)
-            .send(exampleQuestion);
+        it('should return BAD REQUEST IF quizId not found', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/100/questions')
+                .set('Authorization', token)
+                .send(exampleQuestion);
 
-        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
-        expect(response.body).toMatchObject({
-            status: 'fail',
-            message: expect.anything()
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
+            });
         });
-    });
 
-    it('should return NOT FOUND IF courseId not found', async () => {
-        const response = await request(app)
-            .post('/courses/100/quizzes/1/questions')
-            .set('Authorization', token)
-            .send(exampleQuestion);
+        it('should return NOT FOUND IF courseId not found', async () => {
+            const response = await request(app)
+                .post('/courses/100/quizzes/1/questions')
+                .set('Authorization', token)
+                .send(exampleQuestion);
 
-        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
-        expect(response.body).toMatchObject({
-            status: 'fail',
-            message: expect.anything()
+            expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
+            });
         });
     });
 };

--- a/src/__tests__/tests/quizTest.ts
+++ b/src/__tests__/tests/quizTest.ts
@@ -147,9 +147,23 @@ export const QuestionInstructorTest = () => {
         });
 
         it('should return UNAUTHORIZED IF form is valid ' +
-            'and logged in as instructor', async () => {
+            'and logged in', async () => {
             const response = await request(app)
                 .post('/courses/1/quizzes/1/questions')
+                .send(exampleQuestion);
+
+            expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);
+            expect(response.body).toMatchObject({
+                status: 'fail',
+                message: expect.anything()
+            });
+        });
+
+        it('should return UNAUTHORIZED IF form is valid' +
+            'and not logged in as instructor', async () => {
+            const response = await request(app)
+                .post('/courses/1/quizzes/1/questions')
+                .set('Authorization', 'Bearer invalid_token')
                 .send(exampleQuestion);
 
             expect(response.statusCode).toBe(StatusCodes.UNAUTHORIZED);

--- a/src/__tests__/tests/quizTest.ts
+++ b/src/__tests__/tests/quizTest.ts
@@ -188,4 +188,30 @@ export const QuizInstructorTest = () => {
             });
         });
     });
+
+    it('should return BAD REQUEST IF quizId not found', async () => {
+        const response = await request(app)
+            .post('/courses/1/quizzes/100/questions')
+            .set('Authorization', token)
+            .send(exampleQuestion);
+
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+        expect(response.body).toMatchObject({
+            status: 'fail',
+            message: expect.anything()
+        });
+    });
+
+    it('should return NOT FOUND IF courseId not found', async () => {
+        const response = await request(app)
+            .post('/courses/100/quizzes/1/questions')
+            .set('Authorization', token)
+            .send(exampleQuestion);
+
+        expect(response.statusCode).toBe(StatusCodes.NOT_FOUND);
+        expect(response.body).toMatchObject({
+            status: 'fail',
+            message: expect.anything()
+        });
+    });
 };

--- a/src/controllers/course.controller.ts
+++ b/src/controllers/course.controller.ts
@@ -8,11 +8,11 @@ import { courseIdSchema, courseSchema } from '../validations/course.validate';
 
 class CourseController {
 
-    async add(req: Request, res: Response) {
+    async addNewCourse(req: Request, res: Response) {
         const userPayload = await authService.getTokenPayload(req, 'ACCESS');
         const body = validate(req, courseSchema, 'body');
 
-        await courseService.add(userPayload!, body);
+        await courseService.addNewCourse(userPayload!, body);
 
         return sendResponse(res, {
             statusCode: StatusCodes.CREATED,

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -1,0 +1,33 @@
+import type { Request, Response } from 'express';
+import { StatusCodes } from 'http-status-codes';
+import { authService } from '../services/auth.service';
+import { quizService } from '../services/quiz.service';
+import { sendResponse } from '../utils/api.util';
+import { validate } from '../utils/validate.util';
+import {
+    quizParamsSchema,
+    addQuestionSchema
+} from '../validations/quiz.validate';
+
+class QuizController {
+
+    async addNewQuestion(req: Request, res: Response) {
+        const userPayload = await authService.getTokenPayload(req, 'ACCESS');
+        const params = validate(req, quizParamsSchema, 'params');
+        const body = validate(req, addQuestionSchema, 'body');
+
+        await quizService.addNewQuestion(
+            params.courseId,
+            params.quizId,
+            userPayload!.userId, body);
+
+        return sendResponse(res, {
+            statusCode: StatusCodes.CREATED,
+            success: true,
+            message: 'Successfully created a question.'
+        });
+    }
+
+}
+
+export const quizController = new QuizController();

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -24,14 +24,16 @@ router.post('/courses/:courseId/enroll', authenticate('ACCESS'),
     courseEnrollmentController.enrollNewCourse);
 
 // Course & Modules
+// Role Student
 router.get('/courses', authenticate('ACCESS'),
     courseController.getVerifiedCourses);
-router.post('/courses', authenticate('ACCESS'), courseController.add);
 router.get('/courses/:courseId', authenticate('ACCESS'),
     courseController.getCourseDetail);
-router.post('/courses', authenticate('ACCESS'), courseController.add);
 router.get('/courses/:courseId/modules/lectures', authenticate('ACCESS'),
     moduleController.getEnrolledLecturesForStudent);
+
+// Role Instructor
+router.post('/courses', authenticate('ACCESS'), courseController.addNewCourse);
 router.post('/courses/:courseId/modules/lectures', authenticate('ACCESS'),
     moduleController.addLecture);
 router.post('/courses/:courseId/modules/quizzes', authenticate('ACCESS'),

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -6,6 +6,7 @@ import {
     courseEnrollmentController
 } from '../controllers/courseEnrollment.controller';
 import { moduleController } from '../controllers/module.controller';
+import { quizController } from '../controllers/quiz.controller';
 
 import { userController } from '../controllers/user.controller';
 import authenticate from '../middlewares/authenticate.middleware';
@@ -46,6 +47,8 @@ router.get('/courses/instructor/own/:courseId', authenticate('ACCESS'),
 // Quizzes
 router.get('/courses/:courseId/quizzes', authenticate('ACCESS'),
     moduleController.getEnrolledCourseQuizzes);
+router.post('/courses/:courseId/quizzes/:quizId/questions',
+    authenticate('ACCESS'), quizController.addNewQuestion);
 
 // Approval
 router.get('/approval/register', authenticate('ACCESS'),

--- a/src/services/course.service.ts
+++ b/src/services/course.service.ts
@@ -10,7 +10,7 @@ import type {
 
 class CourseService {
 
-    async add(
+    async addNewCourse(
         { userId: instructorId, role }: UserPayload,
         rawCourse: CourseType) {
         if (role !== UserRole.INSTRUCTOR) {

--- a/src/services/module.service.ts
+++ b/src/services/module.service.ts
@@ -2,7 +2,7 @@ import type {
     AddLectureType, AddModuleType, DeleteLectureParams
 } from '../validations/module.validate';
 import { courseService } from '../services/course.service';
-import { Errors } from '../utils/error.util';
+import { Errors, ResponseError } from '../utils/error.util';
 import { Module, ModuleType } from '../database/entities/Module';
 import { Lecture } from '../database/entities/Lecture';
 import { Quiz } from '../database/entities/Quiz';
@@ -14,6 +14,7 @@ import type {
     CourseWithTotalType,
     CourseIdType
 } from '../validations/course.validate';
+import { StatusCodes } from 'http-status-codes';
 
 class ModuleService {
 
@@ -67,6 +68,17 @@ class ModuleService {
         });
 
         await Quiz.save(quizData);
+    }
+
+    async getQuiz(quizId: number) {
+        const quiz = await Quiz.findOneBy({ id: quizId });
+        if (!quiz) {
+            throw new ResponseError(
+                'Quiz not found.',
+                StatusCodes.NOT_FOUND);
+        }
+
+        return quiz;
     }
 
     async getEnrolledLecturesForStudent(

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -29,7 +29,7 @@ class QuizService {
             question: rawQuestion.question,
         };
 
-        const answersData: questionOptionType[] =
+        const questionOptions: questionOptionType[] =
             rawQuestion.questionOptions;
 
         const questionSave = Question.create({ ...questionData });
@@ -37,14 +37,14 @@ class QuizService {
 
         const questionId = question.id;
 
-        answersData.map(async (answer: questionOptionType) => {
-            const answerData = {
+        questionOptions.map(async (answer: questionOptionType) => {
+            const options = {
                 questionId,
                 option: answer.option,
                 isCorrectAnswer: answer.isCorrectAnswer,
             };
 
-            const answerSave = QuestionOption.create({ ...answerData });
+            const answerSave = QuestionOption.create({ ...options });
             await QuestionOption.save(answerSave);
         });
     }

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -4,7 +4,7 @@ import { QuestionOption } from '../database/entities/QuestionOption';
 import type { UserPayload } from '../typings/auth';
 import { Errors, ResponseError } from '../utils/error.util';
 import type {
-    questionOptionType, quizType
+    QuestionOptionType, QuizType
 } from '../validations/quiz.validate';
 import { courseService } from './course.service';
 import { moduleService } from './module.service';
@@ -15,7 +15,7 @@ class QuizService {
         courseId: number,
         quizId: number,
         userId: UserPayload['userId'],
-        rawQuestion: quizType) {
+        rawQuestion: QuizType) {
 
         if (rawQuestion.questionOptions.length < 2) {
             throw new ResponseError(
@@ -37,7 +37,7 @@ class QuizService {
             question: rawQuestion.question,
         };
 
-        const questionOptions: questionOptionType[] =
+        const questionOptions: QuestionOptionType[] =
             rawQuestion.questionOptions;
 
         const questionSave = Question.create({ ...questionData });
@@ -45,7 +45,7 @@ class QuizService {
 
         const questionId = question.id;
 
-        questionOptions.map(async (answer: questionOptionType) => {
+        questionOptions.map(async (answer: QuestionOptionType) => {
             const options = {
                 questionId,
                 option: answer.option,

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -1,0 +1,54 @@
+import { Question } from '../database/entities/Question';
+import { QuestionOption } from '../database/entities/QuestionOption';
+import type { UserPayload } from '../typings/auth';
+import { Errors } from '../utils/error.util';
+import type {
+    questionOptionType, quizType
+} from '../validations/quiz.validate';
+import { courseService } from './course.service';
+import { moduleService } from './module.service';
+
+class QuizService {
+
+    async addNewQuestion(
+        courseId: number,
+        quizId: number,
+        userId: UserPayload['userId'],
+        rawQuestion: quizType) {
+
+        const course = await courseService.get(courseId);
+
+        if (course.instructorId !== userId) {
+            throw Errors.NO_PERMISSION;
+        }
+
+        await moduleService.getQuiz(quizId);
+
+        const questionData = {
+            quizId: quizId,
+            question: rawQuestion.question,
+        };
+
+        const answersData: questionOptionType[] =
+            rawQuestion.questionOptions;
+
+        const questionSave = Question.create({ ...questionData });
+        const question = await Question.save(questionSave);
+
+        const questionId = question.id;
+
+        answersData.map(async (answer: questionOptionType) => {
+            const answerData = {
+                questionId,
+                option: answer.option,
+                isCorrectAnswer: answer.isCorrectAnswer,
+            };
+
+            const answerSave = QuestionOption.create({ ...answerData });
+            await QuestionOption.save(answerSave);
+        });
+    }
+
+}
+
+export const quizService = new QuizService();

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -1,7 +1,8 @@
+import { StatusCodes } from 'http-status-codes';
 import { Question } from '../database/entities/Question';
 import { QuestionOption } from '../database/entities/QuestionOption';
 import type { UserPayload } from '../typings/auth';
-import { Errors } from '../utils/error.util';
+import { Errors, ResponseError } from '../utils/error.util';
 import type {
     questionOptionType, quizType
 } from '../validations/quiz.validate';
@@ -15,6 +16,13 @@ class QuizService {
         quizId: number,
         userId: UserPayload['userId'],
         rawQuestion: quizType) {
+
+        if (rawQuestion.questionOptions.length < 2) {
+            throw new ResponseError(
+                'Question must have at least two option.',
+                StatusCodes.BAD_REQUEST,
+            );
+        }
 
         const course = await courseService.get(courseId);
 

--- a/src/validations/quiz.validate.ts
+++ b/src/validations/quiz.validate.ts
@@ -1,46 +1,46 @@
 import joi from 'joi';
 
-export interface quizParamType {
+export interface QuizParamType {
     courseId: number;
     quizId: number;
 }
 
-export interface quizAnswerParamType {
+export interface QuizAnswerParamType {
     questionId: number;
 }
 
-export interface quizType extends quizParamType {
+export interface QuizType extends QuizParamType {
     question: string;
-    questionOptions: questionOptionType[];
+    questionOptions: QuestionOptionType[];
 }
 
-export interface addUserAnswerType extends quizAnswerParamType {
+export interface AddUserAnswerType extends QuizAnswerParamType {
     userId: number;
-    quizOptionId: number;
+    questionOptionId: number;
 }
 
-export interface questionOptionType {
+export interface QuestionOptionType {
     option: string;
     isCorrectAnswer: boolean;
 }
 
-export const quizParamsSchema = joi.object<quizParamType>({
+export const quizParamsSchema = joi.object<QuizParamType>({
     courseId: joi.number()
         .required(),
     quizId: joi.number()
         .required()
 });
 
-export const quizAnswerParamsSchema = joi.object<quizAnswerParamType>({
+export const quizAnswerParamsSchema = joi.object<QuizAnswerParamType>({
     questionId: joi.number()
         .required()
 });
 
-export const addQuestionSchema = joi.object<quizType>({
+export const addQuestionSchema = joi.object<QuizType>({
     question: joi.string()
         .required(),
     questionOptions: joi.array()
-        .items(joi.object<questionOptionType>({
+        .items(joi.object<QuestionOptionType>({
             option: joi.string()
                 .required(),
             isCorrectAnswer: joi.boolean()
@@ -48,14 +48,14 @@ export const addQuestionSchema = joi.object<quizType>({
         }))
 });
 
-export const addUserAnswerSchema = joi.object<addUserAnswerType>({
+export const addUserAnswerSchema = joi.object<AddUserAnswerType>({
     userId: joi.number()
         .required(),
-    quizOptionId: joi.number()
+    questionOptionId: joi.number()
         .required()
 });
 
-export const addQuestionOptionSchema = joi.object<questionOptionType>({
+export const addQuestionOptionSchema = joi.object<QuestionOptionType>({
     option: joi.string()
         .required(),
     isCorrectAnswer: joi.boolean()

--- a/src/validations/quiz.validate.ts
+++ b/src/validations/quiz.validate.ts
@@ -1,0 +1,64 @@
+import joi from 'joi';
+
+export interface quizParamType {
+    courseId: number;
+    quizId: number;
+}
+
+export interface quizAnswerParamType {
+    questionId: number;
+}
+
+export interface quizType extends quizParamType {
+    question: string;
+    questionOptions: questionOptionType[];
+}
+
+export interface addUserAnswerType extends quizAnswerParamType {
+    userId: number;
+    quizOptionId: number;
+}
+
+export interface questionOptionType {
+    option: string;
+    isCorrectAnswer: boolean;
+}
+
+export const quizParamsSchema = joi.object<quizParamType>({
+    courseId: joi.number()
+        .required(),
+    quizId: joi.number()
+        .required()
+});
+
+export const quizAnswerParamsSchema = joi.object<quizAnswerParamType>({
+    questionId: joi.number()
+        .required()
+});
+
+export const addQuestionSchema = joi.object<quizType>({
+    question: joi.string()
+        .required(),
+    questionOptions: joi.array()
+        .items(joi.object<questionOptionType>({
+            option: joi.string()
+                .required(),
+            isCorrectAnswer: joi.boolean()
+                .required()
+        }))
+});
+
+export const addUserAnswerSchema = joi.object<addUserAnswerType>({
+    userId: joi.number()
+        .required(),
+    quizOptionId: joi.number()
+        .required()
+});
+
+export const addQuestionOptionSchema = joi.object<questionOptionType>({
+    option: joi.string()
+        .required(),
+    isCorrectAnswer: joi.boolean()
+        .required()
+});
+


### PR DESCRIPTION
#### Issue: https://trello.com/c/bNEXDcsZ/70-be-create-an-endpoint-to-add-questions-and-answers-in-specific-quiz
#### How to reproduce:
HIT POST /courses/:courseId/quizzes/:quizId/questions
Authentication: ACCESS

#### Example JSON Data:
```json
{
	"question": "Apa itu backend?",
	"questionOptions": [
		{
			"option": "Jawaban 1",
			"isCorrectAnswer": false
		},
		{
			"option": "Jawaban 2",
			"isCorrectAnswer": false
		},
		{
			"option": "Jawaban 3",
			"isCorrectAnswer": true
		},
		{
			"option": "Jawaban 4",
			"isCorrectAnswer": false
		},
		{
			"option": "Jawaban 5",
			"isCorrectAnswer": false
		}
	]
}
```

#### Results:
IF user not instructor:
Status code: BAD REQUEST
```json
{
	"status": "fail",
	"message": "You don't have the permission to access this content."
}
```
IF success:
Status code: CREATED
```json
{
	"status": "success",
	"message": "Successfully created a question."
}
```