### PR TITLE
Feature/rafi/create an endpoint to view all questions and answers in specified quiz

### DIFF
--- a/src/controllers/courseEnrollment.controller.ts
+++ b/src/controllers/courseEnrollment.controller.ts
@@ -15,7 +15,7 @@ class CourseEnrollmentController {
         const courseId = validate(req, courseEnrollmentSchema, 'params');
 
         await courseEnrollmentService.enrollNewCourse(
-            userPayload!, courseId);
+            courseId, userPayload!.userId);
 
         return sendResponse(res, {
             statusCode: StatusCodes.OK,

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -40,7 +40,7 @@ class QuizController {
         return sendResponse(res, {
             statusCode: StatusCodes.OK,
             success: true,
-            data: questions,
+            data: { questions },
             message: 'Successfully retrieved all questions and options.',
         });
     }

--- a/src/controllers/quiz.controller.ts
+++ b/src/controllers/quiz.controller.ts
@@ -28,6 +28,23 @@ class QuizController {
         });
     }
 
+    async ViewAllQuestionsAndOptions(req: Request, res: Response) {
+        const userPayload = await authService.getTokenPayload(req, 'ACCESS');
+        const params = validate(req, quizParamsSchema, 'params');
+
+        const questions = await quizService.ViewAllQuestionsAndOptions(
+            params.courseId,
+            params.quizId,
+            userPayload!);
+
+        return sendResponse(res, {
+            statusCode: StatusCodes.OK,
+            success: true,
+            data: questions,
+            message: 'Successfully retrieved all questions and options.',
+        });
+    }
+
 }
 
 export const quizController = new QuizController();

--- a/src/database/entities/Question.ts
+++ b/src/database/entities/Question.ts
@@ -20,7 +20,7 @@ export class Question extends BaseEntity {
     @Column({ name: 'quiz_id' })
     quizId!: number;
 
-    @Column({ length: 128 })
+    @Column({ length: 128, select: false })
     question!: string;
 
     @ManyToOne(() => Quiz, (quiz) => quiz.questions)

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -52,6 +52,10 @@ router.get('/courses/:courseId/quizzes', authenticate('ACCESS'),
 router.post('/courses/:courseId/quizzes/:quizId/questions',
     authenticate('ACCESS'), quizController.addNewQuestion);
 
+// Role Instructor and Student
+router.get('/courses/:courseId/quizzes/:quizId',
+    authenticate('ACCESS'), quizController.ViewAllQuestionsAndOptions);
+
 // Approval
 router.get('/approval/register', authenticate('ACCESS'),
     userController.getAllNewInstructor);

--- a/src/services/courseEnrollment.service.ts
+++ b/src/services/courseEnrollment.service.ts
@@ -3,7 +3,6 @@ import { CourseEnrollment } from '../database/entities/CourseEnrollment';
 import type {
     AddCourseEnrollmentType
 } from '../validations/courseEnrollment.validate';
-import type { UserPayload } from '../typings/auth';
 import { ResponseError } from '../utils/error.util';
 import { Course } from '../database/entities/Course';
 
@@ -11,7 +10,7 @@ class CourseEnrollmentService {
 
     async enrollNewCourse(
         { courseId }: AddCourseEnrollmentType,
-        userId: UserPayload['userId']) {
+        userId: number) {
         const userCourseEnrolled = await CourseEnrollment
             .find({
                 where: {
@@ -40,7 +39,7 @@ class CourseEnrollmentService {
 
     async getCourseEnrollment(
         courseId: number,
-        userId: UserPayload['userId']) {
+        userId: number) {
         const courseEnrollment = await CourseEnrollment
             .findOne({
                 where: {

--- a/src/services/courseEnrollment.service.ts
+++ b/src/services/courseEnrollment.service.ts
@@ -10,9 +10,8 @@ import { Course } from '../database/entities/Course';
 class CourseEnrollmentService {
 
     async enrollNewCourse(
-        userPayload: UserPayload,
-        { courseId }: AddCourseEnrollmentType) {
-        const userId = userPayload.userId;
+        { courseId }: AddCourseEnrollmentType,
+        userId: UserPayload['userId']) {
         const userCourseEnrolled = await CourseEnrollment
             .find({
                 where: {
@@ -37,6 +36,26 @@ class CourseEnrollmentService {
         const enrollCourse = CourseEnrollment.create(
             { userId, courseId });
         await CourseEnrollment.save(enrollCourse);
+    }
+
+    async getCourseEnrollment(
+        courseId: number,
+        userId: UserPayload['userId']) {
+        const courseEnrollment = await CourseEnrollment
+            .findOne({
+                where: {
+                    userId,
+                    courseId
+                }
+            });
+
+        if (!courseEnrollment) {
+            throw new ResponseError(
+                'Course not enrolled.',
+                StatusCodes.BAD_REQUEST);
+        }
+
+        return courseEnrollment;
     }
 
 }

--- a/src/services/quiz.service.ts
+++ b/src/services/quiz.service.ts
@@ -16,7 +16,7 @@ class QuizService {
     async addNewQuestion(
         courseId: number,
         quizId: number,
-        userId: UserPayload['userId'],
+        userId: number,
         rawQuestion: QuizType) {
 
         if (rawQuestion.questionOptions.length < 2) {


### PR DESCRIPTION
#### Issue: https://trello.com/c/29I1sqVq/49-be-create-an-endpoint-to-view-all-questions-and-quiz-options-in-specified-quiz
#### How to reproduce:
HIT GET /courses/:courseId/quizzes/:quizId
Authentication: Access
Role: Instructor / Student who enrolled the course

#### Results:
IF success:
Status Code: 200
```json
{
	"status": "success",
	"data": [
		{
			"id": 1,
			"question": "Apa itu backend?",
			"questionOptions": [
				{
					"id": 1,
					"questionId": 1,
					"option": "Jawaban 1"
				},
				{
					"id": 2,
					"questionId": 1,
					"option": "Jawaban 3"
				},
				{
					"id": 3,
					"questionId": 1,
					"option": "Jawaban 4"
				},
				{
					"id": 4,
					"questionId": 1,
					"option": "Jawaban 5"
				},
				{
					"id": 5,
					"questionId": 1,
					"option": "Jawaban 2"
				}
			]
		},
		....
	],
	"message": "Successfully retrieved all questions and options."
}
```

IF Not enrolled:
Status Code: 400
```json
{
	"status": "fail",
	"message": "Course not enrolled."
}
```

NB: Do unit testing later. Not tested for other conditions